### PR TITLE
Removing unnecessary JSON response wrapping.

### DIFF
--- a/taskgv.py
+++ b/taskgv.py
@@ -60,9 +60,6 @@ HEADER = "digraph  dependencies { layout=neato;   splines=true; overlap=scalexy;
 
 FOOTER = "}"
 
-JSON_START = '['
-JSON_END = ']'
-
 validUuids = list()
 
 def call_taskwarrior(cmd):
@@ -73,7 +70,7 @@ def call_taskwarrior(cmd):
 def get_json(query):
     'call taskwarrior, returning objects from json'
     result, err = call_taskwarrior('end.after:today xor status:pending export %s' % query)
-    return json.loads(JSON_START + result + JSON_END)
+    return json.loads(result.decode("utf-8"))
 
 def call_dot(instr):
     'call dot, returning stdout and stdout'


### PR DESCRIPTION
This commit addresses #5 by removing the additional JSON mapping. The result from the subprocess execution is already wrapped in a list, so this stops the program wrapping that in a list again.