### PR TITLE
Switching all png output to svg.

### DIFF
--- a/taskgv.py
+++ b/taskgv.py
@@ -77,7 +77,7 @@ def get_json(query):
 
 def call_dot(instr):
     'call dot, returning stdout and stdout'
-    dot = Popen('dot -Tpng'.split(), stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    dot = Popen('dot -Tsvg'.split(), stdout=PIPE, stderr=PIPE, stdin=PIPE)
     return dot.communicate(instr.encode('utf-8'))
 
 if __name__ == '__main__':
@@ -169,18 +169,18 @@ if __name__ == '__main__':
     lines.append(FOOTER)
 
     print ('Calling dot')
-    png, err = call_dot('\n'.join(lines))
+    svg, err = call_dot('\n'.join(lines))
     if err != '':
         print ('Error calling dot:')
         print (err.strip())
 
-    print ('Writing to /tmp/taskgv.png')
-    with open('/tmp/taskgv.png', 'w') as f:
-        f.write(png)
+    print ('Writing to /tmp/taskgv.svg')
+    with open('/tmp/taskgv.svg', 'w') as f:
+        f.write(svg)
 
 # Use `xdg-open` if it's present, `open` otherwise.
 display_command = spawn.find_executable("xdg-open")
 if display_command == None:
     display_command = spawn.find_executable("open")
 
-subprocess.call(display_command + " /tmp/taskgv.png", shell = True)
+subprocess.call(display_command + " /tmp/taskgv.svg", shell = True)


### PR DESCRIPTION
For particularly large graphs, dot isn't able to render via png and just throws an error.

This is somewhat of a hack, as it'd probably be better to detect that particular error message and just run the process again with svg, rather than running them all with it. However, it's just as easy to display svg on linux as png, so there's no _real_ loss as far as I'm aware.